### PR TITLE
adicionar função marcar tarefa como concluída

### DIFF
--- a/Funcoes.c
+++ b/Funcoes.c
@@ -176,8 +176,24 @@ void removerTarefa(Lista *l, int id) {
     }
 }
 
-void marcar_conclusao_de_uma_tarefa_especifica(Lista *l) {
-    
+  void marcar_conclusao_de_uma_tarefa_especifica(Lista l) {
+    mostrar_tarefas_cadastradas(l);
+
+    if (l.posicaoAtual == 0) {
+        printf("Nenhuma tarefa cadastrada.\n");
+        return;
+    }
+
+    int indice;
+    printf("Digite o numero da tarefa concluida: ");
+    scanf("%d", &indice);
+
+    if (indice >= 1 && indice <= l.posicaoAtual) {
+        strcpy(l.tarefas [indice - 1].Status, "CONCLUIDA");
+        printf("Tarefa marcada como concluida.\n");
+    } else {
+        printf("Indice invalido.\n");
+    }
 }
 
 void salvar_lista_de_tarefas_em_um_arquivo(Lista *l) {


### PR DESCRIPTION
A função marcar_conclusao_de_uma_tarefa_especifica exibe as tarefas cadastradas, permite ao usuário selecionar uma tarefa pelo número e a marca como "CONCLUIDA" se o índice for válido, mostrando mensagens apropriadas de feedback ao usuário.